### PR TITLE
Replace Clerk auth with database-backed login flow

### DIFF
--- a/app/api/endpoints/auth.py
+++ b/app/api/endpoints/auth.py
@@ -8,20 +8,14 @@ from app.db.database import get_db
 from app.audit.logger import HIPAAAuditLogger
 from app.services.email_service import email_service
 from jose import JWTError, jwt
-from jwt import PyJWKClient
 from datetime import datetime, timedelta
-from typing import Optional
-import os
 import secrets
 import logging
-from pydantic import BaseModel
+from typing import Optional
 
 from app.config import settings
 
 logger = logging.getLogger(__name__)
-
-clerk_jwk_client: Optional[PyJWKClient] = None
-clerk_jwk_url: Optional[str] = None
 
 SECRET_KEY = settings.secret_key
 ALGORITHM = settings.algorithm
@@ -31,10 +25,6 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token", auto_error=False)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-
-class ClerkLoginRequest(BaseModel):
-    email: Optional[str] = None
-    username: Optional[str] = None
 
 # Utility to create JWT token
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
@@ -64,10 +54,10 @@ def get_current_user(request: Request, token: Optional[str] = Depends(oauth2_sch
         try:
             payload = jwt.decode(active_token, SECRET_KEY, algorithms=[ALGORITHM])
         except JWTError:
-            payload = _verify_clerk_token(active_token)
+            payload = None
 
         if not payload:
-            logger.warning("JWT decode failed for both local and Clerk tokens")
+            logger.warning("JWT decode failed for local token")
             raise credentials_exception
 
         username: str = payload.get("sub") or payload.get("username")
@@ -81,89 +71,10 @@ def get_current_user(request: Request, token: Optional[str] = Depends(oauth2_sch
         raise credentials_exception
     user = crud_notes.get_user_by_username(db, username)
 
-    # Auto-provision Clerk users when first seen.
-    if user is None and _is_clerk_subject(username):
-        user = _provision_clerk_user(db, payload)
-
     if user is None:
         logger.warning(f"User '{username}' not found after token validation")
         raise credentials_exception
     return user
-
-
-def _is_clerk_subject(subject: str) -> bool:
-    return bool(subject and subject.startswith("user_"))
-
-
-def _verify_clerk_token(token: str) -> Optional[dict]:
-    global clerk_jwk_client, clerk_jwk_url
-
-    configured_issuer = (os.getenv("CLERK_JWT_ISSUER") or os.getenv("CLERK_ISSUER") or "").strip().rstrip("/")
-    configured_jwks_url = (os.getenv("CLERK_JWKS_URL") or "").strip()
-
-    token_issuer = ""
-    try:
-        token_issuer = (jwt.get_unverified_claims(token).get("iss") or "").strip().rstrip("/")
-    except Exception:
-        token_issuer = ""
-
-    issuer = configured_issuer or token_issuer
-    jwks_url = configured_jwks_url or (f"{issuer}/.well-known/jwks.json" if issuer else "")
-    if not jwks_url:
-        logger.warning("Clerk token verification skipped: missing CLERK_ISSUER/CLERK_JWKS_URL and no token issuer")
-        return None
-
-    try:
-        if clerk_jwk_client is None or clerk_jwk_url != jwks_url:
-            clerk_jwk_client = PyJWKClient(jwks_url)
-            clerk_jwk_url = jwks_url
-
-        signing_key = clerk_jwk_client.get_signing_key_from_jwt(token)
-        decode_kwargs = {
-            "key": signing_key.key,
-            "algorithms": ["RS256"],
-            "options": {"verify_aud": False},
-        }
-
-        if issuer:
-            try:
-                return jwt.decode(token, issuer=issuer, **decode_kwargs)
-            except Exception:
-                return jwt.decode(token, **decode_kwargs)
-
-        return jwt.decode(token, **decode_kwargs)
-    except Exception as error:
-        logger.warning(f"Clerk token verification failed: {error}")
-        return None
-
-
-def _provision_clerk_user(db: Session, payload: dict) -> Optional[models.User]:
-    clerk_subject = payload.get("sub")
-    if not clerk_subject:
-        return None
-
-    email = payload.get("email") or f"{clerk_subject}@clerk.local"
-    username = payload.get("preferred_username") or clerk_subject
-
-    existing_email = db.query(models.User).filter(func.lower(models.User.email) == email.lower()).first()
-    if existing_email:
-        return existing_email
-
-    hashed_password = crud_notes.get_password_hash(secrets.token_urlsafe(32))
-    new_user = models.User(
-        username=username,
-        email=email,
-        hashed_password=hashed_password,
-        tenant_id="default",
-        is_active=1,
-        is_admin=0,
-        role="provider",
-    )
-    db.add(new_user)
-    db.commit()
-    db.refresh(new_user)
-    logger.info(f"Auto-provisioned Clerk user: {username}")
-    return new_user
 
 # POST /auth/register - Register a new user.
 # No authentication required.
@@ -319,41 +230,6 @@ def login_cookie(request: Request, response: Response, form_data: OAuth2Password
 
     return {"access_token": access_token, "token_type": "bearer"}
 
-
-@router.post("/clerk-login", response_model=schemas.Token)
-def clerk_login(
-    request: Request,
-    payload: ClerkLoginRequest,
-    db: Session = Depends(get_db),
-):
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing Clerk bearer token")
-
-    clerk_token = auth_header.split(" ", 1)[1].strip()
-    verified_payload = _verify_clerk_token(clerk_token)
-    if not verified_payload:
-        raise HTTPException(status_code=401, detail="Invalid Clerk token")
-
-    username = verified_payload.get("preferred_username") or verified_payload.get("sub")
-    if not username:
-        raise HTTPException(status_code=401, detail="Missing Clerk subject")
-
-    user = crud_notes.get_user_by_username(db, username)
-    if user is None:
-        user = _provision_clerk_user(db, verified_payload)
-
-    if user is None:
-        # Last fallback: attempt email match if available
-        email = (payload.email or verified_payload.get("email") or "").strip().lower()
-        if email:
-            user = db.query(models.User).filter(func.lower(models.User.email) == email).first()
-
-    if user is None:
-        raise HTTPException(status_code=401, detail="Unable to map Clerk user")
-
-    access_token = create_access_token(data={"sub": user.username})
-    return {"access_token": access_token, "token_type": "bearer"}
 
 @router.post("/logout")
 def logout(response: Response):

--- a/app/crud/notes.py
+++ b/app/crud/notes.py
@@ -175,7 +175,14 @@ def get_password_hash(password: str) -> str:
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
 def authenticate_user(db: Session, username: str, password: str):
+    normalized_input = (username or "").strip().lower()
     user = get_user_by_username(db, username)
+    if not user and "@" in normalized_input:
+        user = (
+            db.query(models.User)
+            .filter(func.lower(func.trim(models.User.email)) == normalized_input)
+            .first()
+        )
     if not user:
         return None, "User not found"
 

--- a/scribsy-frontend/README.md
+++ b/scribsy-frontend/README.md
@@ -2,12 +2,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-Set Clerk environment variables before running locally:
-
-```bash
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
-CLERK_SECRET_KEY=sk_test_...
-```
+Authentication is handled by the backend user database. Create an account from `/register` or seed users in the API database before signing in.
 
 First, run the development server:
 

--- a/scribsy-frontend/package-lock.json
+++ b/scribsy-frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "scribsy-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@clerk/nextjs": "^6.39.0",
         "@heroicons/react": "^2.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -44,104 +43,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@clerk/backend": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.0.tgz",
-      "integrity": "sha512-sVR214TlJ5vsRprDE9EiZpqeNq/YVhCQLtAZ19ugjNf1C9xMX28JoMyodI/dU5FLBelmgSyjBAjodPULjIeF+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/shared": "^3.47.2",
-        "@clerk/types": "^4.101.20",
-        "standardwebhooks": "^1.0.0",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      }
-    },
-    "node_modules/@clerk/clerk-react": {
-      "version": "5.61.3",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.3.tgz",
-      "integrity": "sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==",
-      "deprecated": "This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/shared": "^3.47.2",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
-        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
-      }
-    },
-    "node_modules/@clerk/nextjs": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.0.tgz",
-      "integrity": "sha512-T9LS/C0lly5eHmyH79RFi1afF45IHWZw7CZkudRK2zsJaxn7SjrHURYDNp6O5Cdcm/OmjYrND0PC0eKZh/jfRA==",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/backend": "^2.33.0",
-        "@clerk/clerk-react": "^5.61.3",
-        "@clerk/shared": "^3.47.2",
-        "@clerk/types": "^4.101.20",
-        "server-only": "0.0.1",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      },
-      "peerDependencies": {
-        "next": "^13.5.7 || ^14.2.25 || ^15.2.3 || ^16",
-        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
-        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
-      }
-    },
-    "node_modules/@clerk/shared": {
-      "version": "3.47.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.2.tgz",
-      "integrity": "sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "3.1.3",
-        "dequal": "2.0.3",
-        "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.5",
-        "std-env": "^3.9.0",
-        "swr": "2.3.4"
-      },
-      "engines": {
-        "node": ">=18.17.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
-        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@clerk/types": {
-      "version": "4.101.20",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.20.tgz",
-      "integrity": "sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==",
-      "deprecated": "This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3",
-      "license": "MIT",
-      "dependencies": {
-        "@clerk/shared": "^3.47.2"
-      },
-      "engines": {
-        "node": ">=18.17.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1432,12 +1333,6 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2768,6 +2663,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2890,15 +2786,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3651,12 +3538,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense"
-    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -3938,12 +3819,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -4642,15 +4517,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
-      }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -5847,12 +5713,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/server-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
-      "license": "MIT"
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -6078,22 +5938,6 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
-    },
-    "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -6410,19 +6254,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/swr": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
-      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tailwind-merge": {
@@ -6901,15 +6732,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/scribsy-frontend/package.json
+++ b/scribsy-frontend/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@clerk/nextjs": "^6.39.0",
     "@heroicons/react": "^2.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/scribsy-frontend/src/app/layout.tsx
+++ b/scribsy-frontend/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import { ClerkProvider } from '@clerk/nextjs';
 import "./globals.css";
 import { AuthProvider } from '@/lib/auth';
 import { ThemeProvider } from '@/lib/theme-provider';
@@ -19,8 +18,6 @@ export const metadata: Metadata = {
   description: "Transform your clinical conversations into structured SOAP notes with AI-powered transcription and summarization.",
 };
 
-const clerkPublishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-
 function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider
@@ -29,7 +26,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
       enableSystem={false}
       disableTransitionOnChange
     >
-      <AuthProvider enableClerk={Boolean(clerkPublishableKey)}>
+      <AuthProvider>
         <ToastProvider>
           <SidebarProvider>
             <SidebarFrame>
@@ -53,9 +50,9 @@ export default function RootLayout({
     "default-src 'self'",
     "img-src 'self' data: blob: https:",
     "style-src 'self' 'unsafe-inline'",
-    "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.clerk.accounts.dev https://*.clerk.com",
+    "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
     "connect-src 'self' https: wss:",
-    "frame-src 'self' https://*.clerk.accounts.dev https://*.clerk.com",
+    "frame-src 'self'",
     "font-src 'self' data:",
   ].join("; ");
 
@@ -63,13 +60,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.className} antialiased`}>
         <meta httpEquiv="Content-Security-Policy" content={csp} />
-        {clerkPublishableKey ? (
-          <ClerkProvider publishableKey={clerkPublishableKey}>
-            <AppShell>{children}</AppShell>
-          </ClerkProvider>
-        ) : (
-          <AppShell>{children}</AppShell>
-        )}
+        <AppShell>{children}</AppShell>
       </body>
     </html>
   );

--- a/scribsy-frontend/src/app/login/page.tsx
+++ b/scribsy-frontend/src/app/login/page.tsx
@@ -1,38 +1,24 @@
 'use client';
 
-import { SignIn } from '@clerk/nextjs';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
-const hasClerkKey = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
-
-function ClerkLogin() {
+export default function LoginPage() {
   const router = useRouter();
-  const { user, loading } = useAuth();
-
-  useEffect(() => {
-    if (!loading && user) {
-      router.replace('/dashboard');
-    }
-  }, [loading, router, user]);
-
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 px-4">
-      <SignIn routing="path" signUpUrl="/register" forceRedirectUrl="/dashboard" />
-    </div>
-  );
-}
-
-function LegacyLogin() {
-  const router = useRouter();
-  const { login } = useAuth();
+  const { login, user, loading: authLoading } = useAuth();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!authLoading && user) {
+      router.replace('/dashboard');
+    }
+  }, [authLoading, router, user]);
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-slate-50 px-4">
@@ -60,8 +46,4 @@ function LegacyLogin() {
       </form>
     </div>
   );
-}
-
-export default function LoginPage() {
-  return hasClerkKey ? <ClerkLogin /> : <LegacyLogin />;
 }

--- a/scribsy-frontend/src/app/register/page.tsx
+++ b/scribsy-frontend/src/app/register/page.tsx
@@ -1,23 +1,12 @@
 'use client';
 
-import { SignUp } from '@clerk/nextjs';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
-const hasClerkKey = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
-
-function ClerkRegister() {
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 px-4">
-      <SignUp routing="hash" signInUrl="/login" forceRedirectUrl="/dashboard" />
-    </div>
-  );
-}
-
-function LegacyRegister() {
+export default function RegisterPage() {
   const router = useRouter();
   const { register } = useAuth();
   const [formData, setFormData] = useState({ username: '', email: '', password: '', confirmPassword: '' });
@@ -56,8 +45,4 @@ function LegacyRegister() {
       </form>
     </div>
   );
-}
-
-export default function RegisterPage() {
-  return hasClerkKey ? <ClerkRegister /> : <LegacyRegister />;
 }

--- a/scribsy-frontend/src/lib/api.ts
+++ b/scribsy-frontend/src/lib/api.ts
@@ -199,28 +199,6 @@ class ApiClient {
     return this.handleResponse<User>(response);
   }
 
-  async loginWithClerk(
-    clerkToken: string,
-    profile?: { email?: string; username?: string },
-    options?: { suppressAuthFailure?: boolean }
-  ): Promise<LoginResponse> {
-    const response = await fetch(`${this.baseURL}/auth/clerk-login`, {
-      method: 'POST',
-      headers: {
-        ...this.getJsonHeaders(),
-        Authorization: `Bearer ${clerkToken}`,
-      },
-      body: JSON.stringify({
-        email: profile?.email,
-        username: profile?.username,
-      }),
-      credentials: this.requestCredentials(),
-    });
-    const result = await this.handleResponse<LoginResponse>(response, options);
-    this.setToken(result.access_token);
-    return result;
-  }
-
   async refreshSession(): Promise<LoginResponse> {
     const response = await fetch(`${this.baseURL}/auth/refresh`, {
       method: 'POST',

--- a/scribsy-frontend/src/lib/auth.tsx
+++ b/scribsy-frontend/src/lib/auth.tsx
@@ -2,8 +2,6 @@
 
 import { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { useAuth as useClerkAuth } from '@clerk/nextjs';
-import { useUser } from '@clerk/nextjs';
 import { User, LoginRequest, RegisterRequest } from '@/types';
 import { apiClient } from '@/lib/api';
 
@@ -74,109 +72,8 @@ function LegacyAuthProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-function ClerkAuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
-  const router = useRouter();
-  const { isLoaded, isSignedIn, getToken, signOut } = useClerkAuth();
-  const { user: clerkUser } = useUser();
-
-  const handleAuthFailure = useCallback(() => {
-    apiClient.clearToken();
-    setUser(null);
-    if (typeof window !== 'undefined' && window.location.pathname !== '/login' && window.location.pathname !== '/register' && window.location.pathname !== '/') {
-      router.push('/login');
-    }
-  }, [router]);
-
-  useEffect(() => {
-    const initAuth = async () => {
-      if (!isLoaded) return;
-      if (!isSignedIn) {
-        apiClient.clearToken();
-        setUser(null);
-        setLoading(false);
-        return;
-      }
-
-      try {
-        // Basic login flow:
-        // 1) get Clerk token, 2) load API user, 3) fallback to clerk-login exchange, 4) retry briefly.
-        let currentUser: User | null = null;
-
-        for (let attempt = 0; attempt < 5; attempt++) {
-          const token = await getToken();
-          if (!token) {
-            await new Promise((resolve) => setTimeout(resolve, 300));
-            continue;
-          }
-
-          apiClient.setToken(token);
-
-          try {
-            currentUser = await apiClient.getCurrentUser({ suppressAuthFailure: true });
-            break;
-          } catch {
-            try {
-              await apiClient.loginWithClerk(
-                token,
-                {
-                  email: clerkUser?.primaryEmailAddress?.emailAddress ?? undefined,
-                  username: clerkUser?.username ?? undefined,
-                },
-                { suppressAuthFailure: true }
-              );
-              currentUser = await apiClient.getCurrentUser({ suppressAuthFailure: true });
-              break;
-            } catch {
-              // Backend may still be waiting for session/token propagation.
-              await new Promise((resolve) => setTimeout(resolve, 400));
-            }
-          }
-        }
-
-        if (!currentUser) {
-          throw new Error('Login failed. Unable to establish authenticated session');
-        }
-
-        setUser(currentUser);
-      } catch {
-        handleAuthFailure();
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    initAuth();
-    apiClient.setAuthFailureCallback(handleAuthFailure);
-  }, [clerkUser, getToken, handleAuthFailure, isLoaded, isSignedIn]);
-
-  const login = async () => {
-    router.push('/login');
-  };
-
-  const register = async () => {
-    router.push('/register');
-  };
-
-  const logout = async () => {
-    apiClient.clearToken();
-    await signOut({ redirectUrl: '/' });
-    setUser(null);
-  };
-
-  return (
-    <AuthContext.Provider value={{ user, loading, isLoading: loading, login, register, logout, handleAuthFailure }}>
-      {children}
-    </AuthContext.Provider>
-  );
-}
-
-export function AuthProvider({ children, enableClerk = false }: { children: React.ReactNode; enableClerk?: boolean }) {
-  if (!enableClerk) {
-    return <LegacyAuthProvider>{children}</LegacyAuthProvider>;
-  }
-  return <ClerkAuthProvider>{children}</ClerkAuthProvider>;
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  return <LegacyAuthProvider>{children}</LegacyAuthProvider>;
 }
 
 export function useAuth() {


### PR DESCRIPTION
### Motivation
- Remove the external Clerk dependency and simplify authentication to use the application's user database and local JWTs only.
- Make the login flow predictable and self-contained so users can sign in with credentials stored in the app DB or via email.

### Description
- Frontend: removed Clerk usage and conditional flows, updated `AuthProvider` to always use the legacy DB-backed provider, and removed Clerk UI components from `src/app/login/page.tsx` and `src/app/register/page.tsx`.
- Frontend: removed `loginWithClerk` from `scribsy-frontend/src/lib/api.ts`, removed `@clerk/nextjs` from `scribsy-frontend/package.json`, refreshed the lockfile, and updated `scribsy-frontend/README.md` to reflect DB-backed auth.
- Backend: removed Clerk token verification, auto-provisioning and the `/auth/clerk-login` exchange in `app/api/endpoints/auth.py`, and kept token validation to local JWT decoding only.
- Auth lookup: updated `app/crud/notes.py` `authenticate_user` to allow signing in by email (detects `@` in input and matches `User.email`) in addition to username matching.

### Testing
- Ran `pytest tests/test_auth_flow.py`, which passed.
- Ran `npm run lint`, which failed due to many pre-existing frontend lint issues unrelated to the auth changes (lint error output observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9ce798908331bb2e48e4a8e5a785)